### PR TITLE
consuming DS NPM module in a separate application

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import './globals.css'
+import 'alfabit-ds-doc/styles/globals.css'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/node": "20.5.1",
     "@types/react": "18.2.20",
     "@types/react-dom": "18.2.7",
+    "alfabit-ds-doc": "^0.1.0",
     "autoprefixer": "10.4.15",
     "eslint": "8.47.0",
     "eslint-config-next": "13.4.18",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,14 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
+  presets: [
+    require('alfabit-ds-doc/tailwind.config')
+  ],
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './node_modules/alfabit-ds-doc/components/**/*.{js,ts,jsx,tsx,mdx}'
   ],
   theme: {
     extend: {


### PR DESCRIPTION
# Aplicação que consome o DS

1. Adicionar o pacote do DS ao projeto
    
    ```sh
    yarn add <nome_do_modulo>
    ```
    
2. No mesmo arquivo que importa as camadas do tailwind (geralmente chama `globals.css` ou `styles.css` ) importar o arquivo CSS do DS também
    
    ```tsx
    import './globals.css'
    import '<nome_do_modulo>/styles/globals.css'
    ```
    
3. Dentro do arquivo de configuração do Tailwind, adicionar as configurações do DS como `preset`:
    
    ```tsx
    const config = {
    	presets: [
    		require('<nome_do_modulo>/tailwind.config')
    	]
    	// ... demais configurações ...
    }
    ```
    
4. Adicionar a referência dos arquivos do DS para serem cobertas pelo Tailwind e processadas no PostCSS. Para isso, basta adicionar o caminho dos componentes do DS dentro da propriedade `content`, no mesmo arquivo de configuração do tailwind do passo anterior:

```tsx
const config = {
  content: [
    './pages/**/*.{js,ts,jsx,tsx,mdx}',
    './components/**/*.{js,ts,jsx,tsx,mdx}',
    './app/**/*.{js,ts,jsx,tsx,mdx}',
    './node_modules/<nome_do_modulo>/components/**/*.{js,ts,jsx,tsx,mdx}'
  ]
  // ... demais configurações ...
}
```

---

Pronto, agora é só importar os componentes e estendê-los como queira 💙